### PR TITLE
Remove hardcoded amd64 path to allow multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY . $GOPATH/src/github.com/grafana/grafana
 RUN yum install -y golang make git && \
     cd $GOPATH/src/github.com/grafana/grafana && \
     go run build.go build && \
+    cp $GOPATH/src/github.com/grafana/grafana/bin/linux-`go env GOARCH`/grafana-server /usr/bin/ && \
     yum erase -y golang make git && yum clean all && \
     rm -rf .git
 
@@ -22,4 +23,4 @@ LABEL io.k8s.display-name="Grafana" \
 USER 1001
 
 WORKDIR $GOPATH/src/github.com/grafana/grafana
-ENTRYPOINT ["/go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-server"]
+ENTRYPOINT ["/usr/bin/grafana-server"]


### PR DESCRIPTION
We need to build this container on other archs, and needed to remove the hardcoded amd64 in the entrypoint.  
