### PR TITLE
use separate Dockerfile for internal builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,82 @@
-FROM openshift/origin-release:golang-1.12 AS builder
-
-ENV GOPATH="/go"
-ENV GOBIN="${GOPATH}/bin"
-ENV PATH="${GOBIN}:${PATH}"
-RUN mkdir -p $GOBIN
-
-COPY . $GOPATH/src/github.com/grafana/grafana
-
-#RUN yum install -y make git
-ENV GOFLAGS="-mod=vendor"
-RUN cd $GOPATH/src/github.com/grafana/grafana && go run build.go build
-RUN cp $GOPATH/src/github.com/grafana/grafana/bin/linux-$(go env GOARCH)/grafana-server /usr/bin/
-RUN rm -rf $GOPATH/src/github.com/grafana/grafana/.git
-
-FROM openshift/origin-base
-
-ENV GOPATH="/go"
-ENV GOBIN="${GOPATH}/bin"
-ENV PATH="${GOBIN}:${PATH}"
-RUN mkdir -p $GOBIN
-
-COPY --from=builder /usr/bin/grafana-server /usr/bin/grafana-server
-COPY --from=builder $GOPATH/src/github.com/grafana/grafana $GOPATH/src/github.com/grafana/grafana
-
-LABEL io.k8s.display-name="Grafana" \
-      io.k8s.description="" \
-      io.openshift.tags="openshift" \
-      maintainer="Frederic Branczyk <fbranczy@redhat.com>"
-
-# doesn't require a root user.
-USER 1001
+# Golang build container
+FROM golang:1.12.4
 
 WORKDIR $GOPATH/src/github.com/grafana/grafana
-ENTRYPOINT ["/usr/bin/grafana-server"]
+
+COPY go.mod go.sum ./
+COPY vendor vendor
+
+RUN go mod verify
+
+COPY pkg pkg
+COPY build.go build.go
+COPY package.json package.json
+
+RUN go run build.go build
+
+# Node build container
+FROM node:10.14.2
+
+WORKDIR /usr/src/app/
+
+COPY package.json yarn.lock ./
+COPY packages packages
+
+RUN yarn install --pure-lockfile --no-progress
+
+COPY Gruntfile.js tsconfig.json tslint.json ./
+COPY public public
+COPY scripts scripts
+COPY emails emails
+
+ENV NODE_ENV production
+RUN ./node_modules/.bin/grunt build
+
+# Final container
+FROM debian:stretch-slim
+
+ARG GF_UID="472"
+ARG GF_GID="472"
+
+ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+    GF_PATHS_DATA="/var/lib/grafana" \
+    GF_PATHS_HOME="/usr/share/grafana" \
+    GF_PATHS_LOGS="/var/log/grafana" \
+    GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
+    GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+
+WORKDIR $GF_PATHS_HOME
+
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -qq -y libfontconfig1 ca-certificates && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY conf ./conf
+
+RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
+    groupadd -r -g $GF_GID grafana && \
+    useradd -r -u $GF_UID -g grafana grafana && \
+    mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
+             "$GF_PATHS_PROVISIONING/dashboards" \
+             "$GF_PATHS_PROVISIONING/notifiers" \
+             "$GF_PATHS_LOGS" \
+             "$GF_PATHS_PLUGINS" \
+             "$GF_PATHS_DATA" && \
+    cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" && \
+    cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
+    chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
+    chmod 777 -R "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+
+COPY --from=0 /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-server /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-cli ./bin/
+COPY --from=1 /usr/src/app/public ./public
+COPY --from=1 /usr/src/app/tools ./tools
+COPY tools/phantomjs/render.js ./tools/phantomjs/render.js
+
+EXPOSE 3000
+
+COPY ./packaging/docker/run.sh /run.sh
+
+USER grafana
+ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,35 @@
+FROM openshift/origin-release:golang-1.12 AS builder
+
+ENV GOPATH="/go"
+ENV GOBIN="${GOPATH}/bin"
+ENV PATH="${GOBIN}:${PATH}"
+RUN mkdir -p $GOBIN
+
+COPY . $GOPATH/src/github.com/grafana/grafana
+
+#RUN yum install -y make git
+ENV GOFLAGS="-mod=vendor"
+RUN cd $GOPATH/src/github.com/grafana/grafana && go run build.go build
+RUN cp $GOPATH/src/github.com/grafana/grafana/bin/linux-$(go env GOARCH)/grafana-server /usr/bin/
+RUN rm -rf $GOPATH/src/github.com/grafana/grafana/.git
+
+FROM openshift/origin-base
+
+ENV GOPATH="/go"
+ENV GOBIN="${GOPATH}/bin"
+ENV PATH="${GOBIN}:${PATH}"
+RUN mkdir -p $GOBIN
+
+COPY --from=builder /usr/bin/grafana-server /usr/bin/grafana-server
+COPY --from=builder $GOPATH/src/github.com/grafana/grafana $GOPATH/src/github.com/grafana/grafana
+
+LABEL io.k8s.display-name="Grafana" \
+      io.k8s.description="" \
+      io.openshift.tags="openshift" \
+      maintainer="Frederic Branczyk <fbranczy@redhat.com>"
+
+# doesn't require a root user.
+USER 1001
+
+WORKDIR $GOPATH/src/github.com/grafana/grafana
+ENTRYPOINT ["/usr/bin/grafana-server"]


### PR DESCRIPTION
- `mv Dockerfile Dockerfile.ocp`
- Bring in upstream Dockerfile

CI will fail as it needs https://github.com/openshift/release/pull/4235 first.