### PR TITLE
vendor/modules.txt: fix for Go 1.14

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,5 @@
 # Golang build container
-FROM openshift/origin-release:golang-1.13 AS builder
+FROM openshift/origin-release:golang-1.14 AS builder
 
 WORKDIR $GOPATH/src/github.com/grafana/grafana
 ENV GOFLAGS="-mod=vendor"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,8 +2,10 @@
 cloud.google.com/go/civil
 cloud.google.com/go/compute/metadata
 # github.com/BurntSushi/toml v0.3.1
+## explicit
 github.com/BurntSushi/toml
 # github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f
+## explicit
 github.com/VividCortex/mysqlerr
 # github.com/apache/arrow/go/arrow v0.0.0-20200403134915-89ce1cadb678
 github.com/apache/arrow/go/arrow
@@ -18,6 +20,7 @@ github.com/apache/arrow/go/arrow/internal/flatbuf
 github.com/apache/arrow/go/arrow/ipc
 github.com/apache/arrow/go/arrow/memory
 # github.com/aws/aws-sdk-go v1.29.20
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -72,47 +75,70 @@ github.com/aws/aws-sdk-go/service/s3/s3manager
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beevik/etree v1.1.0
+## explicit
 github.com/beevik/etree
 # github.com/benbjohnson/clock v0.0.0-20161215174838-7dc76406b6d3
+## explicit
 github.com/benbjohnson/clock
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668
+## explicit
 github.com/bradfitz/gomemcache/memcache
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/cheekybits/genny v1.0.0
 github.com/cheekybits/genny/generic
+# github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
+## explicit
 # github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/crewjam/saml v0.0.0-20191031171751-c42136edf9b1
+## explicit
 github.com/crewjam/saml
 github.com/crewjam/saml/logger
 github.com/crewjam/saml/xmlenc
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/denisenkom/go-mssqldb v0.0.0-20190707035753-2be1aa521ff4
+## explicit
 github.com/denisenkom/go-mssqldb
 github.com/denisenkom/go-mssqldb/internal/cp
+# github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51
+## explicit
 # github.com/facebookgo/inject v0.0.0-20180706035515-f23751cae28b
+## explicit
 github.com/facebookgo/inject
+# github.com/facebookgo/stack v0.0.0-20160209184415-751773369052
+## explicit
 # github.com/facebookgo/structtag v0.0.0-20150214074306-217e25fb9691
+## explicit
 github.com/facebookgo/structtag
+# github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870
+## explicit
 # github.com/fatih/color v1.7.0
+## explicit
 github.com/fatih/color
 # github.com/go-macaron/binding v0.0.0-20190806013118-0b4f37bab25b
+## explicit
 github.com/go-macaron/binding
 # github.com/go-macaron/gzip v0.0.0-20160222043647-cad1c6580a07
+## explicit
 github.com/go-macaron/gzip
 # github.com/go-macaron/inject v0.0.0-20160627170012-d8a0b8677191
 github.com/go-macaron/inject
 # github.com/go-macaron/session v0.0.0-20190805070824-1a3cdc6f5659
+## explicit
 github.com/go-macaron/session
 # github.com/go-sql-driver/mysql v1.5.0
+## explicit
 github.com/go-sql-driver/mysql
 # github.com/go-stack/stack v1.8.0
+## explicit
 github.com/go-stack/stack
 # github.com/gobwas/glob v0.2.3
+## explicit
 github.com/gobwas/glob
 github.com/gobwas/glob/compiler
 github.com/gobwas/glob/match
@@ -122,6 +148,7 @@ github.com/gobwas/glob/syntax/lexer
 github.com/gobwas/glob/util/runes
 github.com/gobwas/glob/util/strings
 # github.com/golang/protobuf v1.3.4
+## explicit
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/protoc-gen-go/descriptor
 github.com/golang/protobuf/ptypes
@@ -134,6 +161,7 @@ github.com/golang/snappy
 # github.com/google/flatbuffers v1.11.0
 github.com/google/flatbuffers/go
 # github.com/google/go-cmp v0.3.1
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -143,13 +171,17 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c
 github.com/gopherjs/gopherjs/js
 # github.com/gorilla/websocket v1.4.1
+## explicit
 github.com/gorilla/websocket
 # github.com/gosimple/slug v1.4.2
+## explicit
 github.com/gosimple/slug
 # github.com/grafana/grafana-plugin-model v0.0.0-20190930120109-1fc953a61fb4
+## explicit
 github.com/grafana/grafana-plugin-model/go/datasource
 github.com/grafana/grafana-plugin-model/go/renderer
 # github.com/grafana/grafana-plugin-sdk-go v0.60.0
+## explicit
 github.com/grafana/grafana-plugin-sdk-go/backend
 github.com/grafana/grafana-plugin-sdk-go/backend/grpcplugin
 github.com/grafana/grafana-plugin-sdk-go/backend/log
@@ -160,17 +192,22 @@ github.com/grpc-ecosystem/go-grpc-middleware
 # github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 github.com/grpc-ecosystem/go-grpc-prometheus
 # github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd
+## explicit
 github.com/hashicorp/go-hclog
 # github.com/hashicorp/go-plugin v1.2.2
+## explicit
 github.com/hashicorp/go-plugin
 github.com/hashicorp/go-plugin/internal/plugin
 # github.com/hashicorp/go-version v1.1.0
+## explicit
 github.com/hashicorp/go-version
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
 # github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
+## explicit
 github.com/inconshreveable/log15
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+## explicit
 github.com/jmespath/go-jmespath
 # github.com/jonboulle/clockwork v0.1.0
 github.com/jonboulle/clockwork
@@ -179,27 +216,37 @@ github.com/json-iterator/go
 # github.com/jtolds/gls v4.20.0+incompatible
 github.com/jtolds/gls
 # github.com/jung-kurt/gofpdf v1.10.1
+## explicit
 github.com/jung-kurt/gofpdf
+# github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88
+## explicit
 # github.com/klauspost/compress v1.4.1
+## explicit
 github.com/klauspost/compress/flate
 github.com/klauspost/compress/gzip
 # github.com/klauspost/cpuid v1.2.0
+## explicit
 github.com/klauspost/cpuid
 # github.com/lib/pq v1.2.0
+## explicit
 github.com/lib/pq
 github.com/lib/pq/oid
 github.com/lib/pq/scram
 # github.com/linkedin/goavro/v2 v2.9.7
+## explicit
 github.com/linkedin/goavro/v2
 # github.com/mattetti/filebuffer v1.0.0
 github.com/mattetti/filebuffer
 # github.com/mattn/go-colorable v0.1.6
+## explicit
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.12
+## explicit
 github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.7
 github.com/mattn/go-runewidth
 # github.com/mattn/go-sqlite3 v1.11.0
+## explicit
 github.com/mattn/go-sqlite3
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
@@ -214,24 +261,30 @@ github.com/oklog/run
 # github.com/olekukonko/tablewriter v0.0.4
 github.com/olekukonko/tablewriter
 # github.com/opentracing/opentracing-go v1.1.0
+## explicit
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
 # github.com/patrickmn/go-cache v2.1.0+incompatible
+## explicit
 github.com/patrickmn/go-cache
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.3.0
+## explicit
 github.com/prometheus/client_golang/api
 github.com/prometheus/client_golang/api/prometheus/v1
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.1.0
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.7.0
+## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model
@@ -240,10 +293,13 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be
+## explicit
 github.com/rainycape/unidecode
 # github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
+## explicit
 github.com/robfig/cron
 # github.com/robfig/cron/v3 v3.0.0
+## explicit
 github.com/robfig/cron/v3
 # github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7
 github.com/russellhaering/goxmldsig
@@ -252,6 +308,7 @@ github.com/russellhaering/goxmldsig/types
 # github.com/russross/blackfriday/v2 v2.0.1
 github.com/russross/blackfriday/v2
 # github.com/sergi/go-diff v1.0.0
+## explicit
 github.com/sergi/go-diff/diffmatchpatch
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
@@ -261,19 +318,25 @@ github.com/smartystreets/assertions/internal/go-diff/diffmatchpatch
 github.com/smartystreets/assertions/internal/go-render/render
 github.com/smartystreets/assertions/internal/oglematchers
 # github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
+## explicit
 github.com/smartystreets/goconvey/convey
 github.com/smartystreets/goconvey/convey/gotest
 github.com/smartystreets/goconvey/convey/reporting
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf
+## explicit
 github.com/teris-io/shortid
 # github.com/timberio/go-datemath v0.1.1-0.20200323150745-74ddef604fff
+## explicit
 github.com/timberio/go-datemath
 # github.com/ua-parser/uap-go v0.0.0-20190826212731-daf92ba38329
+## explicit
 github.com/ua-parser/uap-go/uaparser
 # github.com/uber/jaeger-client-go v2.20.1+incompatible
+## explicit
 github.com/uber/jaeger-client-go
 github.com/uber/jaeger-client-go/config
 github.com/uber/jaeger-client-go/internal/baggage
@@ -293,21 +356,31 @@ github.com/uber/jaeger-client-go/transport
 github.com/uber/jaeger-client-go/utils
 github.com/uber/jaeger-client-go/zipkin
 # github.com/uber/jaeger-lib v2.2.0+incompatible
+## explicit
 github.com/uber/jaeger-lib/metrics
 # github.com/unknwon/com v1.0.1
+## explicit
 github.com/unknwon/com
 # github.com/urfave/cli/v2 v2.1.1
+## explicit
 github.com/urfave/cli/v2
 # github.com/xorcare/pointer v1.1.0
+## explicit
 github.com/xorcare/pointer
 # github.com/yudai/gojsondiff v1.0.0
+## explicit
 github.com/yudai/gojsondiff
 github.com/yudai/gojsondiff/formatter
 # github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82
+## explicit
 github.com/yudai/golcs
+# github.com/yudai/pp v2.0.1+incompatible
+## explicit
 # go.uber.org/atomic v1.5.1
+## explicit
 go.uber.org/atomic
 # golang.org/x/crypto v0.0.0-20200406173513-056763e48d71
+## explicit
 golang.org/x/crypto/cast5
 golang.org/x/crypto/ed25519
 golang.org/x/crypto/ed25519/internal/edwards25519
@@ -322,9 +395,11 @@ golang.org/x/crypto/openpgp/s2k
 golang.org/x/crypto/pbkdf2
 golang.org/x/crypto/ripemd160
 # golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+## explicit
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -334,12 +409,14 @@ golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
 # golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+## explicit
 golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
 golang.org/x/sys/unix
@@ -350,10 +427,12 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/tools v0.0.0-20191213221258-04c2e8eff935
+## explicit
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter
 # golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+## explicit
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
 # google.golang.org/appengine v1.6.1
@@ -370,6 +449,7 @@ google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.27.1
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -411,18 +491,25 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc
+## explicit
 gopkg.in/alexcesaro/quotedprintable.v3
 # gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d
+## explicit
 gopkg.in/asn1-ber.v1
 # gopkg.in/ini.v1 v1.46.0
+## explicit
 gopkg.in/ini.v1
 # gopkg.in/ldap.v3 v3.0.2
+## explicit
 gopkg.in/ldap.v3
 # gopkg.in/macaron.v1 v1.3.4
+## explicit
 gopkg.in/macaron.v1
 # gopkg.in/mail.v2 v2.3.1
+## explicit
 gopkg.in/mail.v2
 # gopkg.in/redis.v5 v5.2.9
+## explicit
 gopkg.in/redis.v5
 gopkg.in/redis.v5/internal
 gopkg.in/redis.v5/internal/consistenthash
@@ -430,15 +517,19 @@ gopkg.in/redis.v5/internal/hashtag
 gopkg.in/redis.v5/internal/pool
 gopkg.in/redis.v5/internal/proto
 # gopkg.in/square/go-jose.v2 v2.4.1
+## explicit
 gopkg.in/square/go-jose.v2
 gopkg.in/square/go-jose.v2/cipher
 gopkg.in/square/go-jose.v2/json
 gopkg.in/square/go-jose.v2/jwt
 # gopkg.in/yaml.v2 v2.2.5
+## explicit
 gopkg.in/yaml.v2
 # xorm.io/builder v0.3.6
 xorm.io/builder
 # xorm.io/core v0.7.3
+## explicit
 xorm.io/core
 # xorm.io/xorm v0.8.1
+## explicit
 xorm.io/xorm


### PR DESCRIPTION
ART builds which use Go 1.14 fail because `vendor/modules.txt` isn't valid.