### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -24,7 +24,8 @@ FROM openshift/origin-base
 LABEL io.k8s.display-name="Grafana" \
       io.k8s.description="Grafana is an open-source, general purpose dashboard and graph composer" \
       io.openshift.tags="openshift" \
-      maintainer="Frederic Branczyk <fbranczy@redhat.com>"
+      summary="Grafana is an open-source, general purpose dashboard and graph composer" \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
 
 ARG GF_UID="472"
 ARG GF_GID="472"


### PR DESCRIPTION
Bug 1867510: fix CVP issues due to incorrect labels set

- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value

/cc @openshift/openshift-team-monitoring